### PR TITLE
Fixed syntax errors in Redis Docs.

### DIFF
--- a/CHN-17-Redis.md
+++ b/CHN-17-Redis.md
@@ -44,9 +44,9 @@ execCommandAsync 以异步方式执行 Redis 命令。 它至少需要3个参数
 
 ```c++
 redisClient->execCommandAsync(
-    [](const drogon::nosql::RedisResult &r) {}
+    [](const drogon::nosql::RedisResult &r) {},
     [](const std::exception &err) {
-        LOG_ERROR << "something failed!!! " << e.what();
+        LOG_ERROR << "something failed!!! " << err.what();
     },
     "set name drogon");
 ```
@@ -55,9 +55,9 @@ redisClient->execCommandAsync(
 
 ```c++
 redisClient->execCommandAsync(
-    [](const drogon::nosql::RedisResult &r) {}
+    [](const drogon::nosql::RedisResult &r) {},
     [](const std::exception &err) {
-        LOG_ERROR << "something failed!!! " << e.what();
+        LOG_ERROR << "something failed!!! " << err.what();
     },
     "set myid %s", "587d-4709-86e4");
 ```
@@ -71,9 +71,9 @@ redisClient->execCommandAsync(
             LOG_INFO << "Cannot find variable associated with the key 'name'";
         else
             LOG_INFO << "Name is " << r.asString();
-    }
+    },
     [](const std::exception &err) {
-        LOG_ERROR << "something failed!!! " << e.what();
+        LOG_ERROR << "something failed!!! " << err.what();
     },
     "get name");
 ```
@@ -87,7 +87,7 @@ newTransactionAsync 方法创建一个新事务。 然后就可以像普通的 R
 ```c++
 redisClient->newTransactionAsync([](const RedisTransactionPtr &transPtr) {
     transPtr->execCommandAsync(
-        [](const drogon::nosql::RedisResult &r) { /* this command works */ }
+        [](const drogon::nosql::RedisResult &r) { /* this command works */ },
         [](const std::exception &err) { /* this command failed */ },
     "set name drogon");
 

--- a/ENG-17-Redis.md
+++ b/ENG-17-Redis.md
@@ -45,9 +45,9 @@ execCommandAsync executes Redis commands in an asynchronous manner. It takes at 
 
 ```c++
 redisClient->execCommandAsync(
-    [](const drogon::nosql::RedisResult &r) {}
+    [](const drogon::nosql::RedisResult &r) {},
     [](const std::exception &err) {
-        LOG_ERROR << "something failed!!! " << e.what();
+        LOG_ERROR << "something failed!!! " << err.what();
     },
     "set name drogon");
 ```
@@ -56,9 +56,9 @@ Or set `myid` to `587d-4709-86e4`
 
 ```c++
 redisClient->execCommandAsync(
-    [](const drogon::nosql::RedisResult &r) {}
+    [](const drogon::nosql::RedisResult &r) {},
     [](const std::exception &err) {
-        LOG_ERROR << "something failed!!! " << e.what();
+        LOG_ERROR << "something failed!!! " << err.what();
     },
     "set myid %s", "587d-4709-86e4");
 ```
@@ -72,9 +72,9 @@ redisClient->execCommandAsync(
             LOG_INFO << "Cannot find variable associated with the key 'name'";
         else
             LOG_INFO << "Name is " << r.asString();
-    }
+    },
     [](const std::exception &err) {
-        LOG_ERROR << "something failed!!! " << e.what();
+        LOG_ERROR << "something failed!!! " << err.what();
     },
     "get name");
 ```
@@ -88,7 +88,7 @@ The newTransactionAsync method creates a new transaction. Then the transaction c
 ```c++
 redisClient->newTransactionAsync([](const RedisTransactionPtr &transPtr) {
     transPtr->execCommandAsync(
-        [](const drogon::nosql::RedisResult &r) { /* this command works */ }
+        [](const drogon::nosql::RedisResult &r) { /* this command works */ },
         [](const std::exception &err) { /* this command failed */ },
     "set name drogon");
 


### PR DESCRIPTION
The code in the Redis docs wasn't valid C++, it was missing the commas between the args on the functions, and the exception was named incorrectly. I just tidied them up.