### PR TITLE
Fix typos & some grammatical issues coroutine docs

### DIFF
--- a/ENG-16-Coroutines.md
+++ b/ENG-16-Coroutines.md
@@ -1,33 +1,33 @@
 ## Coroutine
 
-Drogon supports [C++ coroutines][1] starting from version 1.4. They provide a way to flatten the control flow of asyncrynous calls, i.e. escaping the callback hell. With it, asyncrynois programming becomes as easy as synchronous ones.
+Drogon supports [C++ coroutines][1] starting from version 1.4. They provide a way to flatten the control flow of asynchronous calls, i.e. escaping the callback hell. With it, asynchronous programming becomes as easy as synchronous programming.
 
 ### Terminology
 
-This page isn't intended to explain what is a coroutine nor how it works. But to show how to use coroutines in drogon. The usual vocabulary tends get messy as subroutines (functions) uses the same terminology as coroutine does, yet they have slightly different meanings. C++ coroutines could act as they are functions doesn't help either. To reduce confusion, these are the termiology we'll use - they are by no means perfect, but good enough.
+This page isn't intended to explain what is a coroutine nor how it works. But to show how to use coroutines in drogon. The usual vocabulary tends get messy as subroutines (functions) uses the same terminology as coroutine does, yet they have slightly different meanings. The fact that C++ coroutines can act as if they are functions doesn't help either. To reduce confusion, we'll use the termiology that follows - it is by no means perfect, but it is good enough.
 
 **Coroutine** is a function that can suspend execution then resume.<br/> 
-**Return** means a function finishing execution and gives a return value to it caller. Or a coroutine generating an _resumable_ object. Which can be used to resume the coroutine.<br/>
+**Return** means a function finishing execution and fiving a return value to its caller. Or a coroutine generating a _resumable_ object; which can be used to resume the coroutine.<br/>
 **Yield**ing is when a coroutine generates a result for the caller.<br/>
-**co-return** means a coroutine yields and then exit.<br/>
-**(co-)await**ing means the thread is waiting a coroutine to yield. The framework is free to use the thread for other purpose while awaiting.<br/>
+**co-return** means a coroutine yields and then exits.<br/>
+**(co-)await**ing means the thread is waiting for a coroutine to yield. The framework is free to use the thread for other purpose while awaiting.<br/>
 
 ### Enabling coroutines
 
-The coroutine feature in drogon is header only. So the application can use coroutines even if drogon is built without coroutine support. How to enable coroutines depends on the compiler used. GCC >= 10 enables it by setting `-std=c++20 -fcoroutines` while MSVC (tested on MSVC 19.25) does by `/std:c++latest` and `/await` must not be set.
+The coroutine feature in Drogon is header-only. This means the application can use coroutines even if Drogon is built without coroutine support. How to enable coroutines depends on the compiler used. In GCC >= 10 it can be enabled by setting `-std=c++20 -fcoroutines` while with MSVC (tested on MSVC 19.25) it can be enabled with `/std:c++latest` and `/await` must not be set.
 
-Note that drogon's implementation of coroutines won't work on clang (as of clang 12.0). GCC 11 enables coroutines by default when C++20 is enabled. And though GCC 10 does compile coroutines. It contains a compiler bug causing nested coroutine frames not being released; leading to potential memory leak.
+Note that Drogon's implementation of coroutines won't work on clang (as of clang 12.0). GCC 11 enables coroutines by default when C++20 is enabled. And though GCC 10 does compile coroutines, it contains a compiler bug causing nested coroutine frames not being released; leading to potential memory leak.
 
 ### Using coroutines
 
-Each and every coroutine in drogon is suffixed with `Coro`. E,g. `db->execSqlSync()` becomes `db->execSqlCoro()`. `client->sendRequest()`  becomes `client->sendRequestCoro()`, so on and so forth. All coroutines return an _awaitable_ object. Then `co_await` on the object results in a value. The framework is free to use the thread to process IO and tasks when it's awaiting results to arrive - that's the beauty of coroutines. The code looks syncrynous; but it's in fact asyncrynously.
+Each and every coroutine in drogon is suffixed with `Coro`. E,g. `db->execSqlSync()` becomes `db->execSqlCoro()`. `client->sendRequest()`  becomes `client->sendRequestCoro()`, so on and so forth. All coroutines return an _awaitable_ object. Then `co_await` on the object results in a value. The framework is free to use the thread to process IO and tasks when it's awaiting results to arrive - that's the beauty of coroutines. The code looks synchronous; but it's in fact asynchronously.
 
-For example, querying the number of users exists in the database:
+For example, querying the number of users that exist in the database:
 
 ```c++
 app.registerHandler("/num_users",
     [](HttpRequestPtr req, std::function<void(const HttpResponsePtr&)> callback) -> Task<>
-    //                                    Must mark the return type as an _resumable_ ^^^
+    //                                    Must mark the return type as a _resumable_ ^^^
 {
     auto sql = app().getDbClient();
     try
@@ -52,16 +52,16 @@ app.registerHandler("/num_users",
 ```
 
 Notice a few important points:
- 1. Any handler that calls a coroutine MUST return an _resumable_
+ 1. Any handler that calls a coroutine MUST return a _resumable_
     * Turning the handler itself into a coroutine
  2. `co_return` replaces `return` in a coroutine
  3. Most parameters are passed by value
 
-An _resumable_ is an object following the coroutine standard. Don't worry too much about the detail. Just know that if you want the coroutine to yield something typed `T`. Then the return type will be `Task<T>`.
+A _resumable_ is an object following the coroutine standard. Don't worry too much about the details. Just know that if you want the coroutine to yield something typed `T`, then the return type will be `Task<T>`.
 
-Passing most parameters by value is a direct consequence of coroutines being asynchronous. It's impossible to track when a reference goes out of scope as the object may destruct while the coroutine is waiting. Or the reference may live on another thread. Thus, may destruct while the coroutine is executing.
+Passing most parameters by value is a direct consequence of coroutines being asynchronous. It's impossible to track when a reference goes out of scope as the object may destruct while the coroutine is waiting. Or the reference may live on another thread. Thus, it may destruct while the coroutine is executing.
 
-It makes sense to not have the callback but use the straightforward `co_return`. Which is supported, but may cause up to 8% of throughput under certain conditions. Please consider the performance drop and whether it's too great for the use case. Again, the same example:
+It makes sense to not have the callback but to use the straightforward `co_return`. Which is supported, but may cause up to 8% of throughput under certain conditions. Please consider the performance drop and whether it's too great for the use case. Again, the same example:
 
 ```c++
 app.registerHandler("/num_users",
@@ -87,15 +87,15 @@ app.registerHandler("/num_users",
 }
 ```
 
-Calling coroutines from websocket controllers aren't supported yet. Feel free to open an issue if you need the feature.
+Calling coroutines from websocket controllers isn't supported yet. Feel free to open an issue if you need this feature.
 
 ## Common pitfalls
 
 There are some common pitfalls you may encounter when using coroutines. 
 
-### Launching coroutines with lambda capture from function
+### Launching coroutines with lambda capture from a function
 
-Lambda captures and coorutines have seprate lifetime. A coroutine lives until the coroutine frame is destructed. While a lambdas commonly destruct right after call. Thus, due to the async nature of coorutines, the corouitine's leftime can be much longer than the lambda. For example in SQL execution. The lambda destructs right after awaiting for SQL to complete (returns to the event loop to process other events). While the coroutine frame is awaiting SQL. Thus the lambda will have been destructed when SQL has finished.
+Lambda captures and coroutines have seprate lifetimes. A coroutine lives until the coroutine frame is destructed. While lambdas commonly destruct right after being called. Thus, due to the asynchronous nature of coroutines, the coroutines's lifetime can be much longer than the lambda, for example in SQL execution. The lambda destructs right after awaiting for SQL to complete (and returns to the event loop to process other events), while the coroutine frame is awaiting SQL. Thus the lambda will have been destructed when SQL has finished.
 
 Instead of
 
@@ -109,7 +109,7 @@ app().getLoop()->queueInLoop([num] -> AsyncTask {
 // BAD, This will crash
 ```
 
-Drogon provides `async_func` that wraps around the lambda to ensure it's lifetime
+Drogon provides `async_func` that wraps around the lambda to ensure its lifetime
 
 ```c++
 app().getLoop()->queueInLoop(async_func([num] -> Task<void> {
@@ -123,7 +123,7 @@ app().getLoop()->queueInLoop(async_func([num] -> Task<void> {
 
 ### Passing/capturing references into coroutines from function
 
-It's a good practice in C++ to pass objects by reference to reduce unnessary copy. However passing by refence into a coroutine from a function commonly causes issues. This is caused by the the coroutine is in fact async and can have a much longer lifetime compared to a regular function. For example, the following code crashes
+It's a good practice in C++ to pass objects by reference to reduce unnessary copy. However passing by refence into a coroutine from a function commonly causes issues. This is caused by the the coroutine is in fact asynchronous and can have a much longer lifetime compared to a regular function. For example, the following code crashes
 
 ```cpp
 void removeCustomers(const std::string& customer_id)

--- a/ENG-16-Coroutines.md
+++ b/ENG-16-Coroutines.md
@@ -4,7 +4,7 @@ Drogon supports [C++ coroutines][1] starting from version 1.4. They provide a wa
 
 ### Terminology
 
-This page isn't intended to explain what is a coroutine nor how it works. But to show how to use coroutines in drogon. The usual vocabulary tends get messy as subroutines (functions) uses the same terminology as coroutine does, yet they have slightly different meanings. The fact that C++ coroutines can act as if they are functions doesn't help either. To reduce confusion, we'll use the termiology that follows - it is by no means perfect, but it is good enough.
+This page isn't intended to explain what is a coroutine nor how it works. But to show how to use coroutines in drogon. The usual vocabulary tends get messy as subroutines (functions) uses the same terminology as coroutine does, yet they have slightly different meanings. The fact that C++ coroutines can act as if they are functions doesn't help either. To reduce confusion, we'll use the terminology that follows - it is by no means perfect, but it is good enough.
 
 **Coroutine** is a function that can suspend execution then resume.<br/> 
 **Return** means a function finishing execution and fiving a return value to its caller. Or a coroutine generating a _resumable_ object; which can be used to resume the coroutine.<br/>


### PR DESCRIPTION
I fixed some typos and grammatical issues in the coroutine docs. I'm not a native speaker so I can't gurantee that it's perfect, now but I tried my best. :+1: