### PR TITLE
Fixing variable names in examples of wiki.

### DIFF
--- a/ENG-08-1-DataBase-DbClient.md
+++ b/ENG-08-1-DataBase-DbClient.md
@@ -144,9 +144,9 @@ auto f = clientPtr->execSqlAsyncFuture("select * from users where org_name=$1",
 try
 {
     auto result = f.get(); // Block until we get the result or catch the exception;
-    std::cout << r.size() << " rows selected!" << std::endl;
+    std::cout << result.size() << " rows selected!" << std::endl;
     int i = 0;
-    for (auto row : r)
+    for (auto row : result)
     {
         std::cout << i++ << ": user name is " << row["user_name"].as<std::string>() << std::endl;
     }
@@ -174,7 +174,7 @@ try
     auto result = clientPtr->execSqlSync("update users set user_name=$1 where user_id=$2",
                                          "test", 
                                          1); // Block until we get the result or catch the exception;
-    std::cout << r.affectedRows() << " rows updated!" << std::endl;
+    std::cout << result.affectedRows() << " rows updated!" << std::endl;
 }
 catch (const DrogonDbException &e)
 {

--- a/ENG-17-Redis.md
+++ b/ENG-17-Redis.md
@@ -68,7 +68,7 @@ The same execCommandAsync can also retrieve data from Redis.
 ```c++
 redisClient->execCommandAsync(
     [](const drogon::nosql::RedisResult &r) {
-        if (r.type() == RedisResultType::kNull)
+        if (r.type() == RedisResultType::kNil)
             LOG_INFO << "Cannot find variable associated with the key 'name'";
         else
             LOG_INFO << "Name is " << r.asString();


### PR DESCRIPTION
Hello, im testing the framework reading the docs, but it have some inconsistencies:

current:

![image](https://user-images.githubusercontent.com/60560085/166161143-555e7b1a-d7e0-48c5-b351-168a9332f639.png)

but in the drogon code:

![image](https://user-images.githubusercontent.com/60560085/166161199-26e38d92-b5de-4795-841f-f98b6260991d.png)

![image](https://user-images.githubusercontent.com/60560085/166161214-8cde8892-5967-451a-9886-a1a3ed55ba3c.png)

