### PR TITLE
Fix CompareOperator from LIKE to Like

### DIFF
--- a/CHN-08-3-数据库-ORM.md
+++ b/CHN-08-3-数据库-ORM.md
@@ -113,8 +113,8 @@ Criteria("tags @> $?"_sql, "cloud");
 ```c++
 Mapper<Users> mp(dbClientPtr);
 auto users = mp.findBy(
-(Criteria(Users::Cols::_user_name,CompareOperator::LIKE,"李%")&&Criteria(Users::Cols::_gender,CompareOperator::EQ,0))
-||(Criteria(Users::Cols::_user_name,CompareOperator::LIKE,"王%")&&Criteria(Users::Cols::_gender,CompareOperator::EQ,1))
+(Criteria(Users::Cols::_user_name,CompareOperator::Like,"李%")&&Criteria(Users::Cols::_gender,CompareOperator::EQ,0))
+||(Criteria(Users::Cols::_user_name,CompareOperator::Like,"王%")&&Criteria(Users::Cols::_gender,CompareOperator::EQ,1))
 ));
 ```
 
@@ -184,7 +184,7 @@ auto users = mp.orderBy(Users::Cols::_join_time).limit(25).offset(0).findAll();
 
 ```c++
     /// Relationship interfaces
-    void getSKU(const DbClientPtr &clientPtr, 
+    void getSKU(const DbClientPtr &clientPtr,
                 const std::function<void(Skus)> &rcb,
                 const ExceptionCallback &ecb) const;
 ```
@@ -195,7 +195,7 @@ auto users = mp.orderBy(Users::Cols::_join_time).limit(25).offset(0).findAll();
 
 ```c++
     /// Relationship interfaces
-    void getProduct(const DbClientPtr &clientPtr, 
+    void getProduct(const DbClientPtr &clientPtr,
                     const std::function<void(Products)> &rcb,
                     const ExceptionCallback &ecb) const;
 ```
@@ -220,7 +220,7 @@ auto users = mp.orderBy(Users::Cols::_join_time).limit(25).offset(0).findAll();
 上面各个配置的含义跟前一个例子一样，这里不再赘述，因为评价有多个，是复数，所以不用另起一个别名了。按照该设置，drogon_ctl create model之后，products表对应的model中，会增加下面的接口：
 
 ```c++
-    void getReviews(const DbClientPtr &clientPtr, 
+    void getReviews(const DbClientPtr &clientPtr,
                     const std::function<void(std::vector<Reviews>)> &rcb,
                     const ExceptionCallback &ecb) const;
 ```
@@ -228,7 +228,7 @@ auto users = mp.orderBy(Users::Cols::_join_time).limit(25).offset(0).findAll();
 reviews表对应的model中，会增加下面的接口：
 
 ```c++
-    void getProduct(const DbClientPtr &clientPtr, 
+    void getProduct(const DbClientPtr &clientPtr,
                     const std::function<void(Products)> &rcb,
                     const ExceptionCallback &ecb) const;
 ```
@@ -260,7 +260,7 @@ reviews表对应的model中，会增加下面的接口：
 按这个配置生成的products的model会添加如下方法：
 
 ```c++
-    void getCarts(const DbClientPtr &clientPtr, 
+    void getCarts(const DbClientPtr &clientPtr,
                   const std::function<void(std::vector<std::pair<Carts,CartsProducts>>)> &rcb,
                   const ExceptionCallback &ecb) const;
 ```
@@ -268,7 +268,7 @@ reviews表对应的model中，会增加下面的接口：
 carts表的model类会添加如下方法：
 
 ```c++
-    void getProducts(const DbClientPtr &clientPtr, 
+    void getProducts(const DbClientPtr &clientPtr,
                      const std::function<void(std::vector<std::pair<Products,CartsProducts>>)> &rcb,
                      const ExceptionCallback &ecb) const;
 ```

--- a/ENG-08-3-DataBase-ORM.md
+++ b/ENG-08-3-DataBase-ORM.md
@@ -114,8 +114,8 @@ Criteria objects support AND and OR operations. The sum of two criteria objects 
 ```c++
 Mapper<Users> mp(dbClientPtr);
 auto users = mp.findBy(
-(Criteria(Users::Cols::_user_name,CompareOperator::LIKE,"%Smith")&&Criteria(Users::Cols::_gender,CompareOperator::EQ,0))
-||(Criteria(Users::Cols::_user_name,CompareOperator::LIKE,"%Johnson")&&Criteria(Users::Cols::_gender,CompareOperator::EQ,1))
+(Criteria(Users::Cols::_user_name,CompareOperator::Like,"%Smith")&&Criteria(Users::Cols::_gender,CompareOperator::EQ,0))
+||(Criteria(Users::Cols::_user_name,CompareOperator::Like,"%Johnson")&&Criteria(Users::Cols::_gender,CompareOperator::EQ,1))
 ));
 ```
 
@@ -185,7 +185,7 @@ According to this setting, in the model class corresponding to the products tabl
 
 ```c++
     /// Relationship interfaces
-    void getSKU(const DbClientPtr &clientPtr, 
+    void getSKU(const DbClientPtr &clientPtr,
                 const std::function<void(Skus)> &rcb,
                 const ExceptionCallback &ecb) const;
 ```
@@ -196,7 +196,7 @@ At the same time, since the enable_reverse option is set to true, the following 
 
 ```c++
     /// Relationship interfaces
-    void getProduct(const DbClientPtr &clientPtr, 
+    void getProduct(const DbClientPtr &clientPtr,
                     const std::function<void(Products)> &rcb,
                     const ExceptionCallback &ecb) const;
 ```
@@ -221,7 +221,7 @@ At the same time, since the enable_reverse option is set to true, the following 
 The meaning of each configuration above is the same as the previous example, so I won't repeat it here, because there are multiple reviews for a single product, so there is no need to create an alias of reviews. According to this setting, after running `drogon_ctl create model`, the following interface will be added to the model corresponding to the products table:
 
 ```c++
-    void getReviews(const DbClientPtr &clientPtr, 
+    void getReviews(const DbClientPtr &clientPtr,
                     const std::function<void(std::vector<Reviews>)> &rcb,
                     const ExceptionCallback &ecb) const;
 ```
@@ -229,7 +229,7 @@ The meaning of each configuration above is the same as the previous example, so 
 In the model corresponding to the reviews table, the following interface will be added:
 
 ```c++
-    void getProduct(const DbClientPtr &clientPtr, 
+    void getProduct(const DbClientPtr &clientPtr,
                     const std::function<void(Products)> &rcb,
                     const ExceptionCallback &ecb) const;
 ```
@@ -261,7 +261,7 @@ For the pivot table, there is an additional `pivot_table` configuration. The opt
 The model of `products` generated according to this configuration will add the following method:
 
 ```c++
-    void getCarts(const DbClientPtr &clientPtr, 
+    void getCarts(const DbClientPtr &clientPtr,
                   const std::function<void(std::vector<std::pair<Carts,CartsProducts>>)> &rcb,
                   const ExceptionCallback &ecb) const;
 ```
@@ -269,7 +269,7 @@ The model of `products` generated according to this configuration will add the f
 The model class of the carts table will add the following method:
 
 ```c++
-    void getProducts(const DbClientPtr &clientPtr, 
+    void getProducts(const DbClientPtr &clientPtr,
                      const std::function<void(std::vector<std::pair<Products,CartsProducts>>)> &rcb,
                      const ExceptionCallback &ecb) const;
 ```


### PR DESCRIPTION
It seems that `CompareOperator` has `Like`, not `LIKE` as shown on the documentation.

https://github.com/drogonframework/drogon/blob/8b90403bae75025d51f1b0ced83c01771b5837ab/orm_lib/inc/drogon/orm/Criteria.h#L42

Also, trailing spaces were removed.