### PR TITLE
Fix typo in vcpkg docs

### DIFF
--- a/CHN-02-安装.md
+++ b/CHN-02-安装.md
@@ -351,7 +351,7 @@ pip install conan
 
      * 32-Bit: `vcpkg install drogon`
      * 64-Bit: `vcpkg install drogon:x64-windows`
-     * extra : `vcpkg install jsoncpp:x64-windows zlib::x64-windows openssl::x64-windows sqlite3:x64-windows libpq:x64-windows libpqxx:x64-windows drogon[core,ctl,sqlite3,postgres,orm]:x64-windows`
+     * extra : `vcpkg install jsoncpp:x64-windows zlib:x64-windows openssl:x64-windows sqlite3:x64-windows libpq:x64-windows libpqxx:x64-windows drogon[core,ctl,sqlite3,postgres,orm]:x64-windows`
 
      注意:
 

--- a/ENG-02-Installation.md
+++ b/ENG-02-Installation.md
@@ -346,7 +346,7 @@ Assuming that the above environment and library dependencies are all ready, the 
 
      * 32-Bit: `vcpkg install drogon`
      * 64-Bit: `vcpkg install drogon:x64-windows`
-     * extra : `vcpkg install jsoncpp:x64-windows zlib::x64-windows openssl::x64-windows sqlite3:x64-windows libpq:x64-windows libpqxx:x64-windows drogon[core,ctl,sqlite3,postgres,orm]:x64-windows`
+     * extra : `vcpkg install jsoncpp:x64-windows zlib:x64-windows openssl:x64-windows sqlite3:x64-windows libpq:x64-windows libpqxx:x64-windows drogon[core,ctl,sqlite3,postgres,orm]:x64-windows`
 
      note:
 


### PR DESCRIPTION
:: was used instead of : to denote triplets