### PR TITLE
Fix a bug in building the Windows version of Drogon

### DIFF
--- a/CHN/CHN-02-安装.md
+++ b/CHN/CHN-02-安装.md
@@ -276,7 +276,8 @@ pip install conan
 * #### Windows 源码安装
 
   1. 下载Drogon源码
-
+      
+      打开Windows任务栏搜索框搜索x64 Native Tools，选择x64 Native Tools Command Prompt for VS 2019作为命令行工具;
       ```shell
       cd $WORK_PATH
       git clone https://github.com/drogonframework/drogon

--- a/ENG/ENG-02-Installation.md
+++ b/ENG/ENG-02-Installation.md
@@ -312,6 +312,7 @@ Assuming that the above environment and library dependencies are all ready, the 
 
   1. Download drogon source
 
+      Open the Windows taskbar search box, search for ​x64 Native Tools, and select ​x64 Native Tools Command Prompt for VS 2019​ as your command-line tool.
       ```dos
       cd $WORK_PATH
       git clone https://github.com/drogonframework/drogon


### PR DESCRIPTION
When executing the conan install command to install the OpenSSL library, Conan attempts to initialize the MSVC development environment. However, when Conan runs the VsDevCmd.bat script during this process, it generates errors including:
'nmake' is not recognized as an internal or external command, along with other environment configuration failures.
Using the x64 Native Tools Command Prompt for VS 2019 as the command-line interface - which properly initializes the MSVC environment - resolves these issues and enables successful command execution.